### PR TITLE
MCP daily: default to no platforms; add dispatch inputs; remove legacy secrets; update README

### DIFF
--- a/.github/workflows/mcp_daily.yml
+++ b/.github/workflows/mcp_daily.yml
@@ -1,0 +1,52 @@
+name: MCP Daily
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no external side-effects)"
+        required: false
+        type: boolean
+        default: false
+      assist_mode:
+        description: "Assistant mode (extra logs/suggestions)"
+        required: false
+        type: boolean
+        default: true
+      PLATFORMS:
+        description: "Comma-separated platform keys to run (empty = none)"
+        required: false
+        type: string
+        default: ""
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  mcp_daily:
+    name: Run MCP daily
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Prepare env from inputs
+        run: |
+          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+          echo "ASSIST_MODE=${{ inputs.assist_mode }}" >> $GITHUB_ENV
+          echo "PLATFORMS=${{ inputs.PLATFORMS }}" >> $GITHUB_ENV
+      - name: Run MCP daily
+        run: |
+          python -u mcp/main.py
+      - name: Upload daily summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily_summaries
+          path: daily_summaries/*.json
+          if-no-files-found: error
+
+    # NOTE: There are intentionally zero references to APPEN_* or TOLOKA_* secrets.
+    # Future adapters can add their own, but default is "no external platforms".

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
-MCP Annotation Agent (GitHub Actions + Playwright)
+# MCP Repo
 
-What it does
-- Logs into supported annotation portals via UI automation (Playwright).
-- Discovers active projects; prioritizes work; falls back to qualifications.
-- Runs up to 5 hours daily; outputs a JSON daily summary.
+## Daily automation (default: **no external platforms**)
 
-Quick start
-1) Add repository secrets (Settings > Secrets and variables > Actions):
-   - APPEN_EMAIL, APPEN_PASSWORD
-   - TOLOKA_EMAIL, TOLOKA_PASSWORD
-2) Adjust schedule in .github/workflows/mcp.yml (cron is UTC).
-3) First runs are dry-run + assist mode (no submissions). Set runtime.dry_run=false to enable real actions.
+This repository includes a GitHub Actions workflow (`.github/workflows/mcp_daily.yml`) that can be run on a schedule or manually via **workflow_dispatch**.
 
-Local dry run (optional)
-- python -m venv .venv && source .venv/bin/activate
-- pip install -r requirements.txt
-- python -m playwright install --with-deps
-- export APPEN_EMAIL=... APPEN_PASSWORD=... TOLOKA_EMAIL=... TOLOKA_PASSWORD=...
-- python mcp/main.py
+**Defaults**
+- No external platforms are enabled by default.
+- When `PLATFORMS` is empty (the default) or contains only invalid keys, the run succeeds and writes a JSON summary at `daily_summaries/summary-<timestamp>.json` with:
+  - `platforms_enabled: 0`
+  - `skipped_reason: "no platforms configured"`
+  - `per_platform: []`
+  - `invalid_platforms: [...]`
+  - and echoes `DRY_RUN` and `ASSIST_MODE`.
 
-Notes
-- UI selectors in adapters are placeholders; adjust to your portals’ DOM.
-- If 2FA is enforced, use a self-hosted runner or persist Playwright storage_state via workflow artifact (already configured).
-- Respect ToS. Keep assist_mode=true unless you have explicit permission for auto-submission.
+**Manual run (workflow_dispatch)**
+- Inputs
+  - `dry_run` (boolean, default `false`)
+  - `assist_mode` (boolean, default `true`)
+  - `PLATFORMS` (string, default `""` = none)
+
+**Artifacts**
+- Each run uploads `daily_summaries/*.json` as an artifact named `daily_summaries`.
+
+## Enabling future platform adapters
+1. Implement an adapter (e.g., under `mcp/adapters/<platform>.py`) and register its key in `SUPPORTED_PLATFORMS` inside `mcp/main.py` (or add a discovery/registry mechanism).
+2. Provide any credentials in the job steps for that adapter (as repository/organization secrets or environment variables).
+3. Trigger a run with `PLATFORMS` set to a comma-separated list of enabled adapter keys (e.g., `PLATFORMS="example1,example2"`).
+
+> Note: All `APPEN_*` and `TOLOKA_*` secret references have been removed from the default workflow. Adapters that require credentials should add their own environment/secret usage locally within their steps.
+
+---
+
+## Test Plan and Acceptance Criteria
+Include this Test Plan and Acceptance Criteria verbatim:
+[paste your test plan and criteria]

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -1,18 +1,81 @@
-import yaml
-import logging
-from pathlib import Path
-from .orchestrator import Orchestrator
+#!/usr/bin/env python3
+"""
+MCP daily entrypoint.
+
+Default behavior: no external platforms are enabled. When PLATFORMS is empty
+or contains only invalid values, write a JSON summary and exit(0).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
 
 
-def load_config():
-    cfg_path = Path(__file__).resolve().parent / "config" / "config.yaml"
-    with open(cfg_path, "r") as f:
-        return yaml.safe_load(f)
+def _as_bool(val: str | None, default: bool) -> bool:
+    if val is None or val == "":
+        return default
+    return str(val).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _ensure_dir(p: pathlib.Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:
+    # Inputs from workflow_dispatch (or schedule with defaults)
+    dry_run = _as_bool(os.getenv("DRY_RUN"), default=False)
+    assist_mode = _as_bool(os.getenv("ASSIST_MODE"), default=True)
+    platforms_raw = (os.getenv("PLATFORMS") or "").strip()
+
+    requested = [p.strip() for p in platforms_raw.split(",") if p.strip()]
+
+    # By default, there are no supported platforms. Future adapters can register here
+    # or via a discovery mechanism.
+    SUPPORTED_PLATFORMS = set()  # e.g., {"appen", "toloka"} once adapters exist
+
+    invalid_platforms = [p for p in requested if p not in SUPPORTED_PLATFORMS]
+    has_any_valid = any(p in SUPPORTED_PLATFORMS for p in requested)
+
+    # If no platforms were provided or all provided are invalid, we write the summary and exit 0.
+    if not requested or not has_any_valid:
+        summary = {
+            "platforms_enabled": 0,
+            "skipped_reason": "no platforms configured",
+            "per_platform": [],
+            "invalid_platforms": invalid_platforms,
+            "DRY_RUN": dry_run,
+            "ASSIST_MODE": assist_mode,
+        }
+        out_dir = pathlib.Path("daily_summaries")
+        _ensure_dir(out_dir)
+        out_file = out_dir / f"summary-{_now_ts()}.json"
+        out_file.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+        print(f"[MCP] Wrote summary: {out_file}")
+        return 0
+
+    # Placeholder for future platform execution path.
+    summary = {
+        "platforms_enabled": 0,
+        "skipped_reason": "no platforms configured",
+        "per_platform": [],
+        "invalid_platforms": invalid_platforms,
+        "DRY_RUN": dry_run,
+        "ASSIST_MODE": assist_mode,
+    }
+    out_dir = pathlib.Path("daily_summaries")
+    _ensure_dir(out_dir)
+    out_file = out_dir / f"summary-{_now_ts()}.json"
+    out_file.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(f"[MCP] Wrote summary: {out_file}")
+    return 0
 
 
 if __name__ == "__main__":
-    cfg = load_config()
-    logging.basicConfig(level=logging.INFO)
-    orch = Orchestrator(cfg, logging.getLogger("mcp"))
-    out = orch.run_daily()
-    print(f"Wrote daily summary to: {out}")
+    sys.exit(main())


### PR DESCRIPTION
### Summary
- Default behavior: no external platforms configured; runs succeed and produce a JSON summary.
- Adds workflow_dispatch inputs:
  - `dry_run` (boolean, default false)
  - `assist_mode` (boolean, default true)
  - `PLATFORMS` (string, default "", meaning none)
- Removes all APPEN_* and TOLOKA_* secret references from the workflow.
- Keeps a daily schedule and uploads `daily_summaries/*.json` as an artifact.
- Updates README to document defaults and how to enable future adapters.

### Test Plan and Acceptance Criteria
Include this Test Plan and Acceptance Criteria verbatim:
[paste your test plan and criteria]

### Notes for future adapters
- Add adapter code and register the key in `SUPPORTED_PLATFORMS` (or via a registry).
- Introduce adapter-specific secrets only where needed in job steps.
